### PR TITLE
Add "prepare" to package.json to consume via npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test": "mocha -r should",
     "build": "webpack",
     "posttest": "xo src lib bin"
+    "prepare": "npm run build",
   },
   "dependencies": {
     "@babel/runtime": "^7.8.4",


### PR DESCRIPTION
- The "prepare" script will run after `npm install` when installing through npm
- https://blog.jim-nielsen.com/2018/installing-and-building-an-npm-package-from-github/